### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Pipeline
 
+permissions:
+  contents: read
+
 on: [push]
 
 env:


### PR DESCRIPTION
Potential fix for [https://github.com/RiccardoSenica/nodejs-template-with-typescript/security/code-scanning/6](https://github.com/RiccardoSenica/nodejs-template-with-typescript/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the least privileges required for the workflow. Based on the provided workflow, the jobs primarily involve running commands, setting up environments, and interacting with the repository contents. Therefore, the minimal required permission is `contents: read`. This will ensure that the `GITHUB_TOKEN` has only read access to the repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
